### PR TITLE
Add ultrasonic sensor for detecting Water Softener salt level

### DIFF
--- a/sensors/water-softener.yaml
+++ b/sensors/water-softener.yaml
@@ -2,6 +2,7 @@
 # water softener salt levels, and an additional temperature sensor onboard just because.
 #
 # Spec: https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf
+# Or see https://esp32.com/viewtopic.php?t=11904 for an easy to read pin-out
 
 substitutions:
   device_name: Water Softener
@@ -43,10 +44,12 @@ i2c:
 sensor:
   # See https://community.home-assistant.io/t/water-tank-level-and-water-volume-with-esphome/192666
   # for a community post about a similar project.
+  # TX/Echo on the sensor goes RX on the board
+  # RX/Trig on the sensor goes TX on the board
   - platform: ultrasonic
-    name: "Water Softener Ultrasonic Sensor"
-    trigger_pin: 3  # RX
-    echo_pin: 1  #TX
+    name: "${device_name} Ultrasonic Sensor"
+    trigger_pin: 17  #TX
+    echo_pin: 16  #RX
     # Set to once per minute for testing.
     update_interval: 60s
   # Temp/humidity sensor

--- a/sensors/water-softener.yaml
+++ b/sensors/water-softener.yaml
@@ -1,0 +1,60 @@
+# This device is a ESP32­WROOM­32. The device has an ultrasonic sensor used for measuring
+# water softener salt levels, and an additional temperature sensor onboard just because.
+#
+# Spec: https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf
+
+substitutions:
+  device_name: Water Softener
+
+esphome:
+  name: water-softener
+  platform: ESP32
+  board: nodemcu-32s
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API and OTA updates
+api:
+  password: !secret api_password
+
+ota:
+  password: !secret ota_password
+
+
+# The AHT10 is an i2c based temperature and humidity sensor.
+# See data sheet:
+# https://wiki.liutyi.info/download/attachments/30507639/Aosong_AHT10_en_draft_0c.pdf
+#
+# The VIN, GND pins are connected to the esp32 on the pins of the same name.  The i2c bus
+# pins SDA and SCL pins are connected to esp32 pins 21 and 22 respectively, and configured
+# below also.
+# See https://esphome.io/components/sensor/aht10.html for details on the sensor.
+i2c:
+  sda: 21
+  scl: 22
+  scan: True
+  id: bus_a
+
+sensor:
+  # See https://community.home-assistant.io/t/water-tank-level-and-water-volume-with-esphome/192666
+  # for a community post about a similar project.
+  - platform: ultrasonic
+    name: "Water Softener Ultrasonic Sensor"
+    trigger_pin: 3  # RX
+    echo_pin: 1  #TX
+    # Set to once per minute for testing.
+    update_interval: 60s
+  # Temp/humidity sensor
+  - platform: aht10
+    temperature:
+      name: "${device_name} Temperature"
+    humidity:
+      name: "${device_name} Humidity"
+    # Set to once per minute for testing.
+    update_interval: 60s
+


### PR DESCRIPTION
Add a Water Softener Salt sensor. This is following a similar tech setup as https://community.home-assistant.io/t/water-tank-level-and-water-volume-with-esphome/192666

The water softener sensor is `MELIFE JSN-SR04T` which has an RX and TX port for the sensor, connected to an ESP32. Since i had extra  AHT10, I threw in one of those also.